### PR TITLE
addressZip geocodes with zip code instead of borough

### DIFF
--- a/nyc_geoclient/api.py
+++ b/nyc_geoclient/api.py
@@ -75,6 +75,23 @@ class Geoclient(object):
         return self._request(u'address', houseNumber=houseNumber, street=street,
                              borough=borough)
 
+    def addressZip(self, houseNumber, street, zip):
+        """
+        Like the above address function, except it uses "zip code" instead of borough
+
+        :param houseNumber:
+            The house number to look up.
+        :param street:
+            The name of the street to look up
+        :param zip:
+            The zip code of the address to look up.
+
+        :returns: A dict with blockface-level, property-level, and political
+            information.
+
+        """
+        return self._request(u'address', houseNumber=houseNumber, street=street, zip=zip)
+
     def bbl(self, borough, block, lot):
         """
         Given a valid borough, block, and lot provides property-level

--- a/nyc_geoclient/api.py
+++ b/nyc_geoclient/api.py
@@ -75,7 +75,7 @@ class Geoclient(object):
         return self._request(u'address', houseNumber=houseNumber, street=street,
                              borough=borough)
 
-    def addressZip(self, houseNumber, street, zip):
+    def address_zip(self, houseNumber, street, zip):
         """
         Like the above address function, except it uses "zip code" instead of borough
 


### PR DESCRIPTION
This add a new method addressZip, which will do the address geocoding with zipcodes instead of borough.

Often you have data with zip codes and not boroughs.

Instead of a whole new method, I suppose you also extend Geoclient.address to be able to handle zips or boroughs, but I think it's simpler this way.  
